### PR TITLE
Add, Remove, Replace functionality and other modifications

### DIFF
--- a/apache-config.sh
+++ b/apache-config.sh
@@ -583,20 +583,21 @@ command_edit()
 }
 
 
+
+
 #Parse requested command, and call the corresponding function with the remaining arguments
-if [ "${1}" = "help" ] || [ "${1}" = "install" ] || [ "${1}" = "enable" ] || [ "${1}" = "disable" ] || [ "${1}" = "check" ] || [ "${1}" = "list" ] || [ "${1}" = "edit" ]
-then
+case $1 in
+help|install|enable|disable|check|list|add|edit)
 	commandFunction="command_${1}"
-	
 	shift
 	"${commandFunction}" "${@}"
-
-#Otherwise, fail with error
-else
+;;
+*) #Otherwise, fail with error
 	echo "Unrecognized command '${1}'" 1>&2
 	printUsageMessage 1>&2
 	exit 2
-fi
+;;
+esac
 
 
 exit 0

--- a/apache-config.sh
+++ b/apache-config.sh
@@ -493,7 +493,7 @@ command_enable() {
 	
 	#Print Apache restart message
 	#printApacheRestart "Enabling"
-	validateReload "" "\"${name}\" ${configType} configuration enabled."
+	validateReload "" "\"${1}\" ${configType} configuration enabled."
 }
 
 
@@ -543,7 +543,7 @@ command_disable() {
 	
 	#Print Apache restart message
 	#printApacheRestart "Disabling"
-	validateReload "" "\"${name}\" ${configType} configuration disabled."
+	validateReload "" "\"${1}\" ${configType} configuration disabled."
 }
 
 command_remove() {

--- a/apache-config.sh
+++ b/apache-config.sh
@@ -534,7 +534,7 @@ command_list()
 }
 
 validateConfig() {
-	httpd -t -f /etc/httpd/conf/httpd.conf "$1" || command_edit
+	httpd -t -f $httpdFile || command_edit
 }
 
 command_add() 
@@ -551,7 +551,7 @@ command_add()
 		exit 1
 	fi
 
-	echo -e "Pipe or Paste Apache configuration content. ctrl-d when done\n"
+	echo -e "Paste Apache configuration content. ctrl-d when done, ctrl+c to cancel\n"
 	newconfig="$(cat)" #end with CTRL+D
 	
 	if [ -n "$newconfig" ]; then

--- a/apache-config.sh
+++ b/apache-config.sh
@@ -66,8 +66,9 @@ printUsageMessage()
 	cat <<-EOF
 		Check installation: ${0} [--quiet] check
 		Install:            ${0} [--quiet] install
-		List configuration: ${0} list (${module} | ${config} | ${site} | ${cleanup}) (enabled | available | disabled)
+		List:               ${0} list (${module} | ${config} | ${site} | ${cleanup}) (enabled | available | disabled)
 		Enable/disable:     ${0} [--quiet] (enable | disable) (${module} | ${config} | ${site} | ${cleanup}) {NAME/PATH} [{NAME/PATH}...]
+		Add:                ${0} [--quiet] edit (${module} | ${config} | ${site} | ${cleanup}) {NAME/PATH}
 		Edit:               ${0} [--quiet] edit (${module} | ${config} | ${site} | ${cleanup}) {NAME/PATH}
 		Help:               ${0} help [--verbose]
 		
@@ -127,6 +128,7 @@ command_help()
 		    "list":     lists all configuration files of the given type and status (enabled, available, or disabled)
 		    "enable":   enables the specified config file type and name
 		    "disable":  disables the specified config file type and name
+		    "add":      creates a new config file for specified type and name, the content can either be piped or pasted in after running the command. Press CTRL+D to finish/save.
 		    "edit":     use the editor specified in VISUAL or EDITOR (falling back to vim or vi if not set) to edit the specified config type and name
 		    
 		Supported types:

--- a/apache-config.sh
+++ b/apache-config.sh
@@ -448,6 +448,9 @@ command_disable()
 	printApacheRestart "Disabling"
 }
 
+command_remove() {
+
+}
 
 #Check for the presence of the environment variable definition in httpd.conf
 checkEnvironmentVariable()
@@ -534,10 +537,13 @@ command_list()
 }
 
 validateConfig() {
-	httpd -t -f $httpdFile || command_edit
+	httpd -t -f $httpdFile #|| command_edit
 }
-restartApache() {
+reloadApache() {
 	apachectl graceful
+}
+validateReload() {
+	validateConfig "$1" && (reloadApache && echoStatus "$2") || echoStatus "A validation error has occurred. Apache has not been reloaded"
 }
 command_add() 
 {
@@ -560,7 +566,8 @@ command_add()
 		touch "$newConf"
 		echo -e "$newconfig" > "$newConf"
 		#validateConfig "$newConf" "add"
-		validateConfig "$newConf" && (restartApache && echoStatus "New ${configType} \"${name}\" configuration added. Apache has been reloaded.") || echoStatus "Apache has not been reloaded"
+		validateReload "$newConf" "New ${configType} \"${name}\" configuration added. Apache has been reloaded."
+		#validateConfig "$newConf" && (restartApache && echoStatus "New ${configType} \"${name}\" configuration added. Apache has been reloaded.") || echoStatus "Apache has not been reloaded"
 	fi
 	
 	#printApacheRestart "Adding"
@@ -583,7 +590,8 @@ command_edit()
 	
 	#Use the editor to edit the config file of the input type and name
 	"${editor}" "${configPath}/${configType}s-${availablePath}/${name}.${fileSuffix}"
-	validateConfig "$newConf" && (restartApache && echoStatus "Editing ${configType} \"${name}\" complete. Apache has been reloaded.") || echoStatus "Apache has not been reloaded"
+	#validateConfig "$newConf" && (restartApache && echoStatus "Editing ${configType} \"${name}\" complete. Apache has been reloaded.") || echoStatus "Apache has not been reloaded"
+	validateReload "$newConf" "Editing ${configType} \"${name}\" complete. Apache has been reloaded."
 }
 
 

--- a/apache-config.sh
+++ b/apache-config.sh
@@ -68,6 +68,7 @@ printUsageMessage()
 		Install:            ${0} [--quiet] install
 		List:               ${0} list (${module} | ${config} | ${site} | ${cleanup}) (enabled | available | disabled)
 		Enable/disable:     ${0} [--quiet] (enable | disable) (${module} | ${config} | ${site} | ${cleanup}) {NAME/PATH} [{NAME/PATH}...]
+		Remove:             ${0} {NAME/PATH}
 		Add:                ${0} [--quiet] edit (${module} | ${config} | ${site} | ${cleanup}) {NAME/PATH}
 		Edit:               ${0} [--quiet] edit (${module} | ${config} | ${site} | ${cleanup}) {NAME/PATH}
 		Help:               ${0} help [--verbose]
@@ -126,8 +127,9 @@ command_help()
 		    "check":    check if the "install" command has been performed
 		    "install":  creates the needed files, directories, and configuration directives needed for this script
 		    "list":     lists all configuration files of the given type and status (enabled, available, or disabled)
-		    "enable":   enables the specified config file type and name
-		    "disable":  disables the specified config file type and name
+		    "enable":   enables the specified config file
+		    "disable":  disables the specified config file
+		    "remove":   removes the specified config file
 		    "add":      creates a new config file for specified type and name, the content can either be piped or pasted in after running the command. Press CTRL+D to finish/save.
 		    "edit":     use the editor specified in VISUAL or EDITOR (falling back to vim or vi if not set) to edit the specified config type and name
 		    
@@ -607,7 +609,7 @@ command_edit() {
 
 #Parse requested command, and call the corresponding function with the remaining arguments
 case $1 in
-help|install|enable|disable|check|list|add|edit)
+help|install|enable|disable|remove|check|list|add|edit)
 	commandFunction="command_${1}"
 	shift
 	"${commandFunction}" "${@}"

--- a/apache-config.sh
+++ b/apache-config.sh
@@ -536,7 +536,9 @@ command_list()
 validateConfig() {
 	httpd -t -f $httpdFile || command_edit
 }
-
+restartApache() {
+	apachectl graceful
+}
 command_add() 
 {
 	#Get the configuration type, then shift it off the arguments
@@ -557,10 +559,11 @@ command_add()
 	if [ -n "$newconfig" ]; then
 		touch "$newConf"
 		echo -e "$newconfig" > "$newConf"
-		validateConfig "$newConf" "add"
+		#validateConfig "$newConf" "add"
+		validateConfig "$newConf" && (restartApache && echoStatus "New ${configType} \"${name}\" configuration added. Apache has been reloaded.") || echoStatus "Apache has not been reloaded"
 	fi
 	
-	printApacheRestart "Adding"
+	#printApacheRestart "Adding"
 }
 
 command_edit()
@@ -580,8 +583,7 @@ command_edit()
 	
 	#Use the editor to edit the config file of the input type and name
 	"${editor}" "${configPath}/${configType}s-${availablePath}/${name}.${fileSuffix}"
-	validateConfig "$newConf" "edit"
-	printApacheRestart "Editing"
+	validateConfig "$newConf" && (restartApache && echoStatus "Editing ${configType} \"${name}\" complete. Apache has been reloaded.") || echoStatus "Apache has not been reloaded"
 }
 
 

--- a/apache-config.sh
+++ b/apache-config.sh
@@ -20,7 +20,7 @@ if which httpd 1>/dev/null 2>&1; then
 	httpdFile="$(grep "SERVER_CONFIG_FILE" <<< "$httpdV" | sed -nr 's@^.+\s*=\s*"(.*)"$@\1@p')" #$httpdConf
 	configRoot="$(sed -e 's@/httpd.conf$@@'  <<< "$httpdFile")" #confRoot
 	httpdConfPath="$httpdRoot/$configRoot"
-	cd "$httpdConfPath"
+	cd "$httpdRoot"
 else
 	# If not present, show an error message and exit with failure
 	cat 1>&2 <<-EOF
@@ -37,7 +37,7 @@ fi
 version="0_1_1"
 environmentVariable="VENDOR_MPLEWIS_CONFIG_CONTROLLER"
 
-configDir="apache-config" #the apache-config dir inside of the apache config dir
+configDir="apache-config" #the apache-config dir inside of the apache  config dir
 configPath="${configRoot}/${configDir}" #absolute path to the apache-config dir
 fileSuffix="conf" #file extension for config files
 controllerFileName="config-controller.${fileSuffix}"


### PR DESCRIPTION
This patch includes some changes to the argument handling and validation routines.

The add and replace now accept stdin in order to allow for scripted usage such as dynamically feeding in config data, i.e. 

```
apache-config replace site example.com <<'EOF'
<VirtualHost *:443>
        Protocols h2 http/1.1

        ServerName example.com
        DocumentRoot /var/www/vhosts/example.com/web
        <Directory /var/www/vhosts/example.com/web>
                AllowOverride All
                Options -Indexes
        </Directory>
        SSLEngine On
        SSLCertificateFile /etc/pki/tls/certs/__.crt
        SSLCertificateKeyFile /etc/pki/tls/private/__.key
        SSLCertificateChainFile /etc/pki/tls/certs/__.ca
</VirtualHost>
EOF
```